### PR TITLE
fix(gatus): use custom build image instead

### DIFF
--- a/.renovate/custom.json5
+++ b/.renovate/custom.json5
@@ -14,4 +14,11 @@
       datasourceTemplate: "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
     },
   ],
+  packageRules: [
+    {
+      matchDataSource: ["docker"],
+      matchPackageNames: ["ghcr.io/kondanta/gatus-certs-fixed"],
+      lookupName: "ghcr.io/twin/gatus"
+    }
+  ]
 }

--- a/infrastructure/apps/observability/gatus/app/helmrelease.yaml
+++ b/infrastructure/apps/observability/gatus/app/helmrelease.yaml
@@ -56,10 +56,8 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/twin/gatus
-              tag: v5.20.0@sha256:e655d13d0cb89c64a2e53a853bbca9556a7238e788bc4a08c19aa5fb7938d0da
-              # repository: ghcr.io/kondanta/gatus-debug
-              # tag: bdaffbc
+              repository: ghcr.io/kondanta/gatus-certs-fixed
+              tag: v5.23.1@sha256:663dda0b3ef369062a624eab8da027f9f899e406210e812a6b2f21e4554637c5
             env:
               TZ: Europe/Oslo
               GATUS_CONFIG_PATH: /config

--- a/infrastructure/apps/observability/gatus/app/resources/config.yaml
+++ b/infrastructure/apps/observability/gatus/app/resources/config.yaml
@@ -29,6 +29,6 @@ storage:
   type: sqlite
   path: /config/sqlite.db
   caching: true
-   
+
 web:
-  port: ${WEB_PORT}    
+  port: ${WEB_PORT}


### PR DESCRIPTION
I fixed the issue. It is about missing certs in the ca-certificates package in alpine. Until I fix this with an automation, or fixed by the remote, I'll use my own image