### PR TITLE
chore(seerr): enable local routing

### DIFF
--- a/infrastructure/apps/media-center/seerr/app/helmrelease.yaml
+++ b/infrastructure/apps/media-center/seerr/app/helmrelease.yaml
@@ -71,6 +71,8 @@ spec:
         parentRefs:
           - name: external
             namespace: network
+          - name: internal
+            namespace: network
     persistence:
       config:
         existingClaim: "{{ .Release.Name }}"


### PR DESCRIPTION
I use split horizon-dns and seerr getting exposed external only breaks full internal
routing flow
