### PR TITLE
chore: add missing memory requests, fix unit typo, and standardize ks labels

### DIFF
--- a/infrastructure/apps/longhorn-system/longhorn/app/helmrelease.yaml
+++ b/infrastructure/apps/longhorn-system/longhorn/app/helmrelease.yaml
@@ -38,6 +38,6 @@ spec:
         memory: 256Mi
     longhornManager:
       resources:
-        memory: 128mi
+        memory: 128Mi
     longhornUI:
       replicas: 1

--- a/infrastructure/apps/media-center/bazarr/app/helmrelease.yaml
+++ b/infrastructure/apps/media-center/bazarr/app/helmrelease.yaml
@@ -42,6 +42,7 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 256Mi
               limits:
                 memory: 512Mi
     defaultPodOptions:

--- a/infrastructure/apps/media-center/bazarr/ks.yaml
+++ b/infrastructure/apps/media-center/bazarr/ks.yaml
@@ -3,8 +3,11 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: bazarr
+  name: &app bazarr
 spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
   interval: 1h
   path: ./infrastructure/apps/media-center/bazarr/app
   postBuild:

--- a/infrastructure/apps/media-center/radarr/app/helmrelease.yaml
+++ b/infrastructure/apps/media-center/radarr/app/helmrelease.yaml
@@ -56,6 +56,7 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                memory: 256Mi
               limits:
                 memory: 1Gi
     defaultPodOptions:

--- a/infrastructure/apps/media-center/radarr/ks.yaml
+++ b/infrastructure/apps/media-center/radarr/ks.yaml
@@ -3,8 +3,11 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: radarr
+  name: &app radarr
 spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
   interval: 1h
   path: ./infrastructure/apps/media-center/radarr/app
   postBuild:

--- a/infrastructure/apps/media-center/sonarr/app/helmrelease.yaml
+++ b/infrastructure/apps/media-center/sonarr/app/helmrelease.yaml
@@ -56,6 +56,7 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                memory: 256Mi
               limits:
                 memory: 1Gi
     defaultPodOptions:

--- a/infrastructure/apps/media-center/sonarr/ks.yaml
+++ b/infrastructure/apps/media-center/sonarr/ks.yaml
@@ -3,8 +3,11 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: sonarr
+  name: &app sonarr
 spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
   interval: 1h
   path: ./infrastructure/apps/media-center/sonarr/app
   postBuild:

--- a/infrastructure/apps/selfhosted/excalidraw/ks.yaml
+++ b/infrastructure/apps/selfhosted/excalidraw/ks.yaml
@@ -3,8 +3,11 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: excalidraw
+  name: &app excalidraw
 spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
   interval: 1h
   components:
     - ../../../../components/fa

--- a/infrastructure/apps/selfhosted/freshrss/ks.yaml
+++ b/infrastructure/apps/selfhosted/freshrss/ks.yaml
@@ -1,9 +1,13 @@
 ---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: freshrss
+  name: &app freshrss
 spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
   dependsOn:
     - name: longhorn
       namespace: longhorn-system


### PR DESCRIPTION
- Add memory requests to bazarr (256Mi), radarr (256Mi), sonarr (256Mi)
- Fix longhornManager memory unit typo: 128mi → 128Mi
- Add commonMetadata labels to radarr, sonarr, bazarr, freshrss, excalidraw ks.yaml
