### PR TITLE
fix(gluetun): bump memory limit

### DIFF
--- a/infrastructure/apps/media-center/qbit/app/helmrelease.yaml
+++ b/infrastructure/apps/media-center/qbit/app/helmrelease.yaml
@@ -68,7 +68,7 @@ spec:
                 cpu: 75m
                 memory: 128Mi
               limits:
-                memory: 512Mi
+                memory: 768Mi
             image:
               repository: ghcr.io/qdm12/gluetun
               tag: v3.41.1


### PR DESCRIPTION
The last 60 days, gluetun was peaked around 570Mi. 
