### PR TITLE
feat(alert): add swap usage alert

### DIFF
--- a/infrastructure/apps/observability/vmstatic-scrapes/prometheusrule-metal.yaml
+++ b/infrastructure/apps/observability/vmstatic-scrapes/prometheusrule-metal.yaml
@@ -74,6 +74,18 @@ spec:
             summary: >-
               {{ $labels.instance }} {{ $labels.mountpoint }} disk above 90% ({{ $value | printf "%.0f" }}%)
 
+        - alert: NASSwapHigh
+          expr: >-
+            (node_memory_SwapTotal_bytes{job="node-exporter-metal", instance="qnap-nas"}
+             - node_memory_SwapFree_bytes{job="node-exporter-metal", instance="qnap-nas"})
+            > 500 * 1024 * 1024
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: >-
+              NAS swap above 500MB for 30m ({{ $value | humanize1024 }}B used)
+
         - alert: MetalHostHighLoad
           expr: >-
             node_load15{job="node-exporter-metal"}


### PR DESCRIPTION
It is an early warning to check NAS' memory status. The machine has
33%~ memory utilization on average, if the swap goes crazy
the videos are starting to get stuttered, and require some investigation to
find the root cause.
