### PR TITLE
refactor: disable node_exporter from nas

### DIFF
--- a/infrastructure/apps/observability/vmstatic-scrapes/qnap.yaml
+++ b/infrastructure/apps/observability/vmstatic-scrapes/qnap.yaml
@@ -6,12 +6,6 @@ metadata:
   namespace: observability
 spec:
   targetEndpoints:
-    - targets: ["10.1.20.100:9100"]
-      labels:
-        job: node-exporter-metal
-        instance: qnap-nas
-      interval: 30s
-      path: /metrics
     - targets: ["10.1.20.100:9094"]
       labels:
         job: qnapexporter


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the unavailable QNAP node-exporter monitoring endpoint.
  * Continued monitoring the QNAP exporter through the existing endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->