### PR TITLE
fix(rclone): downgrade due to proton drive bug

### DIFF
--- a/metal/services/rclone/Dockerfile
+++ b/metal/services/rclone/Dockerfile
@@ -1,4 +1,7 @@
-FROM rclone/rclone:1.75.0
+# Pinned to 1.74.4: 1.75.0 introduced a regression in the Proton Drive backend
+# where 422 responses are mishandled, causing a 422->404 error sequence that
+# breaks sync. See: https://github.com/rclone/rclone/issues/9722
+FROM rclone/rclone:1.74.4
 LABEL org.opencontainers.image.source="https://github.com/kondanta/homelab"
 RUN apk add --no-cache curl dcron tzdata
 COPY sync.sh /usr/local/bin/sync.sh


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pinned the storage service to a compatible version to prevent Proton Drive regressions.
  * Added documentation explaining the version selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->