### PR TITLE
fix(longhorn): add netpol

### DIFF
--- a/infrastructure/apps/longhorn-system/longhorn/app/kustomization.yaml
+++ b/infrastructure/apps/longhorn-system/longhorn/app/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - helmrelease.yaml
+  - networkpolicy.yaml
   - httproute.yaml
   - trim.yaml
   - vmservicescrape.yaml

--- a/infrastructure/apps/longhorn-system/longhorn/app/networkpolicy.yaml
+++ b/infrastructure/apps/longhorn-system/longhorn/app/networkpolicy.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: longhorn-manager-allow-vmagent-scrape
+  namespace: longhorn-system
+spec:
+  podSelector:
+    matchLabels:
+      app: longhorn-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: vmagent
+      ports:
+        - port: 9500
+          protocol: TCP


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added network access rules allowing observability monitoring to reach Longhorn management services on the required port.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->